### PR TITLE
Wait for process id to die before continuing

### DIFF
--- a/rack/bin/teardown
+++ b/rack/bin/teardown
@@ -1,3 +1,5 @@
 #!/bin/sh
 
 kill `cat tmp/server.pid` >/dev/null 2>&1
+wait `cat tmp/server.pid`
+rm -f tmp/server.pid

--- a/ruby_sinatra/bin/teardown
+++ b/ruby_sinatra/bin/teardown
@@ -1,3 +1,5 @@
 #!/bin/sh
 
 kill `cat tmp/server.pid` >/dev/null 2>&1
+wait `cat tmp/server.pid`
+rm -f tmp/server.pid


### PR DESCRIPTION
Prevents possible race condition between test suites.