### PR TITLE
Add failing test for listing clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,10 @@ Each implementation lives in its own subdirectory, and must implement `bin/setup
 
 * `bin/setup`: Gets the server running on port 6969. This also includes installing any dependencies, etc. We can assume that the language itself is installed.
 * `bin/teardown`: Shuts down the server, and cleans up any test artifacts.
+
+Some environment variables if you want to customize the access configuration:
+
+* `EBOSHI_API_SHOOTOUT_MYSQL_USERNAME` _default: 'root'_
+* `EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD` _default: none_
+* `EBOSHI_API_SHOOTOUT_MYSQL_DATABASE` _default: eboshi_test_
+

--- a/bin/test
+++ b/bin/test
@@ -8,7 +8,7 @@ setup() {
 
 test() {
   cd test && npm install && cd ..
-  bin/mocha
+  EBOSHI_API_SHOOTOUT_CURRENT_IMPL=$1 bin/mocha
 }
 
 teardown() {
@@ -16,4 +16,4 @@ teardown() {
   echo ""
 }
 
-setup $1 && test && teardown $1
+setup $1 && test $1 && teardown $1

--- a/ruby_rack/bin/setup
+++ b/ruby_rack/bin/setup
@@ -1,4 +1,4 @@
 #!/bin/sh
-gem list -i rack >/dev/null || gem install rack --no-ri --no-rdoc
+gem list -i rack >/dev/null || gem install rack json mysql2 --no-ri --no-rdoc
 ruby server.rb >/dev/null 2>&1 &
 . $(dirname "$0")/../../bin/server_setup

--- a/ruby_rack/server.rb
+++ b/ruby_rack/server.rb
@@ -43,8 +43,9 @@ class App
     def db
       @db ||= Mysql2::Client.new({
         host: "localhost",
-        username: "root",
-        database: "eboshi_test",
+        username: ENV["EBOSHI_API_SHOOTOUT_MYSQL_USERNAME"] || "root",
+        password: ENV["EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD"] || "",
+        database: ENV["EBOSHI_API_SHOOTOUT_MYSQL_DATABASE"] || "eboshi_test",
         database_timezone: :utc,
       })
     end

--- a/ruby_rack/server.rb
+++ b/ruby_rack/server.rb
@@ -1,9 +1,53 @@
 require "rack"
 require "rack/server"
+require "json"
+require "mysql2"
 
 class App
   def self.call(env)
-    [200, {}, ["Hello world"]]
+    case env["PATH_INFO"]
+    when "/api/test" then HelloWorld.new.call
+    when "/api/clients" then Clients.new.call
+    end
+  end
+
+  class HelloWorld
+    def call
+      [200, {}, ["Hello world"]]
+    end
+  end
+
+  class Clients
+    def call
+      [
+        200,
+       {"Content-type" => "application/json"},
+       [{ data: clients }.to_json],
+      ]
+    end
+
+    private
+
+    def clients
+      db.query("SELECT * FROM clients").map do |attributes|
+        attributes["created_at"] = attributes["created_at"].iso8601
+        attributes["updated_at"] = attributes["updated_at"].iso8601
+        {
+          type: "clients",
+          id: attributes.delete("id").to_s,
+          attributes: attributes,
+        }
+      end
+    end
+
+    def db
+      @db ||= Mysql2::Client.new({
+        host: "localhost",
+        username: "root",
+        database: "eboshi_test",
+        database_timezone: :utc,
+      })
+    end
   end
 end
 

--- a/test/db.js
+++ b/test/db.js
@@ -2,18 +2,22 @@ var mysql = require('mysql');
 
 module.exports = {
     bootstrap: function(done) {
+        var username = process.env['EBOSHI_API_SHOOTOUT_MYSQL_USERNAME'] || 'root';
+        var password = process.env['EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD'] || '';
+        var database = process.env['EBOSHI_API_SHOOTOUT_MYSQL_DATABASE'] || 'eboshi_test';
+
         this.connection = mysql.createConnection({
             host: 'localhost',
-            user: 'root',
-            password: '',
+            user: username,
+            password: password,
         });
 
         var self = this;
 
-        this.query("CREATE DATABASE IF NOT EXISTS `eboshi_test`;", function(err) {
+        this.query("CREATE DATABASE IF NOT EXISTS `" + database + "`;", function(err) {
             if(err) throw err;
 
-            self.query("USE `eboshi_test`;", function(err) {
+            self.query("USE `" + database + "`;", function(err) {
                 if(err) throw err;
 
                 self.query("DROP TABLE IF EXISTS `clients`;", function(err) {

--- a/test/db.js
+++ b/test/db.js
@@ -1,0 +1,46 @@
+var mysql = require('mysql');
+
+module.exports = {
+    bootstrap: function(done) {
+        this.connection = mysql.createConnection({
+            host: 'localhost',
+            user: 'root',
+            password: '',
+        });
+
+        var self = this;
+
+        this.query("CREATE DATABASE IF NOT EXISTS `eboshi_test`;", function(err) {
+            if(err) throw err;
+
+            self.query("USE `eboshi_test`;", function(err) {
+                if(err) throw err;
+
+                self.query("DROP TABLE IF EXISTS `clients`;", function(err) {
+                    if(err) throw err;
+                    self.query(
+                        "CREATE TABLE `clients` (" +
+                        "  `id` int(11) NOT NULL AUTO_INCREMENT," +
+                        "  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `address` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `city` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `state` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `zip` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `country` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `contact` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `phone` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+                        "  `created_at` datetime DEFAULT NULL," +
+                        "  `updated_at` datetime DEFAULT NULL," +
+                        "  PRIMARY KEY (`id`)" +
+                        ") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;",
+                        function(err, res) { if(err) throw err; done(); });
+                  });
+            });
+        });
+    },
+
+    query: function() {
+        this.connection.query.apply(this.connection, arguments);
+    },
+};

--- a/test/package.json
+++ b/test/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "devDependencies": {
     "mocha": "^2.3.3",
+    "mysql": "^2.9.0",
     "supertest": "^1.1.0"
   },
   "repository": "https://github.com/botandrose/eboshi_api_shootout",

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 var supertest = require('supertest');
+var mysql     = require('mysql');
 
 var request = function (path) {
     return supertest('http://localhost:6969')
@@ -6,8 +7,89 @@ var request = function (path) {
     .expect(200);
 }
 
+var connection = mysql.createConnection({
+    host: 'localhost',
+    user: 'root',
+    password: '',
+});
+connection.connect();
+
 describe('/api/test', function() {
     it('returns "Hello world"', function (done) {
         request('/api/test').expect('Hello world', done);
     });
 });
+
+describe('/api/clients', function() {
+    before(function(done) {
+        connection.query("CREATE DATABASE IF NOT EXISTS `eboshi_test`;", function() {
+            connection.database = 'eboshi_test';
+            done();
+        });
+    });
+
+    before(function(done) {
+        connection.query("DROP TABLE IF EXISTS `clients`;", function() { done(); });
+    });
+
+    before(function(done) {
+        connection.query(
+            "CREATE TABLE `clients` (" +
+            "  `id` int(11) NOT NULL AUTO_INCREMENT," +
+            "  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `address` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `city` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `state` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `zip` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `country` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `contact` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `phone` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
+            "  `created_at` datetime DEFAULT NULL," +
+            "  `updated_at` datetime DEFAULT NULL," +
+            "  PRIMARY KEY (`id`)" +
+            ") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;",
+            function() { done(); });
+    });
+
+    before(function(done) {
+        connection.query(
+            "INSERT INTO clients SET " +
+            "  name='Bot and Rose Design', " +
+            "  address='625 NW Everett St', " +
+            "  city='Portland', " +
+            "  state='OR', " +
+            "  zip='97209', " +
+            "  country='USA', " +
+            "  email='info@botandrose.com', " +
+            "  contact='Michael Gubitosa', " +
+            "  phone='(503) 662-2712', " +
+            "  created_at='2006-06-25T14:08:31Z', " +
+            "  updated_at='2015-08-29T09:58:23Z';",
+            function(err) { if(err) throw err; done(); }
+        );
+    });
+
+    it('returns a json list of clients', function (done) {
+        request('/api/clients').expect({
+            "data": [{
+                "type": "clients",
+                "id": "1",
+                "attributes": {
+                    "name": "Bot and Rose Design",
+                    "address": "625 NW Everett St",
+                    "city": "Portland",
+                    "state": "OR",
+                    "zip": "97209",
+                    "country": "USA",
+                    "email": "info@botandrose.com",
+                    "contact": "Michael Gubitosa",
+                    "phone": "(503) 662-2712",
+                    "created_at": "2006-06-25T14:08:31Z",
+                    "updated_at": "2015-08-29T09:58:23Z",
+                },
+            }]
+        }, done);
+    });
+});
+

--- a/test/test.js
+++ b/test/test.js
@@ -1,18 +1,11 @@
 var supertest = require('supertest');
-var mysql     = require('mysql');
+var db = require('./db');
 
 var request = function (path) {
     return supertest('http://localhost:6969')
     .get(path)
     .expect(200);
 }
-
-var connection = mysql.createConnection({
-    host: 'localhost',
-    user: 'root',
-    password: '',
-});
-connection.connect();
 
 describe.skipIfImpl = function(impls, title, fn) {
   var currentImpl = process.env["EBOSHI_API_SHOOTOUT_CURRENT_IMPL"];
@@ -30,39 +23,10 @@ describe('/api/test', function() {
 });
 
 describe.skipIfImpl(['./elixir_phoenix', './node_express', './ruby_rack', './ruby_sinatra'], '/api/clients', function() {
-    before(function(done) {
-        connection.query("CREATE DATABASE IF NOT EXISTS `eboshi_test`;", function() {
-            connection.database = 'eboshi_test';
-            done();
-        });
-    });
+    before(function(done) { db.bootstrap(done); });
 
     before(function(done) {
-        connection.query("DROP TABLE IF EXISTS `clients`;", function() { done(); });
-    });
-
-    before(function(done) {
-        connection.query(
-            "CREATE TABLE `clients` (" +
-            "  `id` int(11) NOT NULL AUTO_INCREMENT," +
-            "  `name` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `address` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `city` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `state` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `zip` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `country` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `email` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `contact` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `phone` varchar(255) COLLATE utf8_unicode_ci DEFAULT NULL," +
-            "  `created_at` datetime DEFAULT NULL," +
-            "  `updated_at` datetime DEFAULT NULL," +
-            "  PRIMARY KEY (`id`)" +
-            ") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;",
-            function() { done(); });
-    });
-
-    before(function(done) {
-        connection.query(
+        db.query(
             "INSERT INTO clients SET " +
             "  name='Bot and Rose Design', " +
             "  address='625 NW Everett St', " +

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,13 @@
-var request = require('supertest');
+var supertest = require('supertest');
+
+var request = function (path) {
+    return supertest('http://localhost:6969')
+    .get(path)
+    .expect(200);
+}
 
 describe('/api/test', function() {
-
-    it('should return Hello world', function (done) {
-        request('http://localhost:6969')
-        .get('/api/test')
-        .expect(200)
-        .expect('Hello world', done);
+    it('returns "Hello world"', function (done) {
+        request('/api/test').expect('Hello world', done);
     });
-
 });

--- a/test/test.js
+++ b/test/test.js
@@ -22,7 +22,7 @@ describe('/api/test', function() {
     });
 });
 
-describe.skipIfImpl(['./elixir_phoenix', './node_express', './ruby_rack', './ruby_sinatra'], '/api/clients', function() {
+describe.skipIfImpl(['./elixir_phoenix', './node_express', './ruby_sinatra'], '/api/clients', function() {
     before(function(done) { db.bootstrap(done); });
 
     before(function(done) {

--- a/test/test.js
+++ b/test/test.js
@@ -14,13 +14,22 @@ var connection = mysql.createConnection({
 });
 connection.connect();
 
+describe.skipIfImpl = function(impls, title, fn) {
+  var currentImpl = process.env["EBOSHI_API_SHOOTOUT_CURRENT_IMPL"];
+  if(impls.indexOf(currentImpl) !== -1) {
+      return this.skip(title, fn);
+  } else {
+      return this(title, fn);
+  };
+};
+
 describe('/api/test', function() {
     it('returns "Hello world"', function (done) {
         request('/api/test').expect('Hello world', done);
     });
 });
 
-describe('/api/clients', function() {
+describe.skipIfImpl(['./elixir_phoenix', './node_express', './ruby_rack', './ruby_sinatra'], '/api/clients', function() {
     before(function(done) {
         connection.query("CREATE DATABASE IF NOT EXISTS `eboshi_test`;", function() {
             connection.database = 'eboshi_test';


### PR DESCRIPTION
@ageoldpun @mradamh Got something ugly working here, definitely gonna clean it up before merge, but wanted your guys' feedback. Notes:

* Added `describe.skipIfImpl` to mocha so that we can add new test cases without making the whole build red. Once you implement the test for a given implementation, just remove the name from the skip list and it'll start testing it.
* Dealing with node's `mysql` library and async makes me want to stab myself in the eyes. You guys know a better way than what I'm doing here?
* I plan on extracting the mysql credentials to environment variables so you guys can customize to your needs.