### PR TITLE
Remove bin/teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,9 @@ Each implementation shares the MySQL database, and a language-agnostic test suit
 Implementation requirements
 ---------------------------
 
-Each implementation lives in its own subdirectory, and must implement `bin/setup` and `bin/teardown`.
+Each implementation lives in its own subdirectory, and has the following requirements:
 
-* `bin/setup`: Gets the server running on port 6969. This also includes installing any dependencies, etc. We can assume that the language itself is installed.
-* `bin/teardown`: Shuts down the server, and cleans up any test artifacts.
-
+* Must provide a `bin/setup` executable. This runs the server on port 6969 after installing any needed dependencies, etc (assume that the language itself is installed).
 * The API response must conform to the [jsonapi.org](http://jsonapi.org) standard.
 * Timestamps must be in UTC and formatted in ISO 8601.
 

--- a/bin/server_setup
+++ b/bin/server_setup
@@ -1,4 +1,0 @@
-#!/bin/sh
-mkdir -p tmp
-echo $! > tmp/server.pid
-until $(curl --output /dev/null --silent --head --fail http://localhost:6969/api/test); do sleep 1; done

--- a/bin/server_shutdown
+++ b/bin/server_shutdown
@@ -1,4 +1,0 @@
-#!/bin/sh
-kill -INT `cat tmp/server.pid` >/dev/null 2>&1
-while $(curl --output /dev/null --silent --head --fail http://localhost:6969/api/test); do sleep 1; done
-rm -f tmp/server.pid

--- a/bin/test
+++ b/bin/test
@@ -3,7 +3,10 @@ set -e
 
 setup() {
   echo $1:
-  cd $1 && bin/setup && cd ..
+  cd $1
+  bin/setup &
+  cd ..
+  until $(curl --output /dev/null --silent --head --fail http://localhost:6969/api/test); do sleep 1; done
 }
 
 test() {
@@ -11,8 +14,10 @@ test() {
 }
 
 teardown() {
-  cd $1 && bin/teardown && cd ..
+  kill -INT `lsof -i TCP:6969 | grep LISTEN | awk '{print $2}' | head -n1`
+  while $(curl --output /dev/null --silent --head --fail http://localhost:6969/api/test); do sleep 1; done
   echo ""
 }
 
-setup $1 && test $1 && teardown $1
+setup $1 && test $1
+teardown

--- a/elixir_phoenix/bin/setup
+++ b/elixir_phoenix/bin/setup
@@ -3,5 +3,4 @@ echo installing phoenix dependencies
 mix local.hex --force >/dev/null
 mix deps.get >/dev/null
 echo running phoenix server
-mix phoenix.server >/dev/null 2>&1 &
-. $(dirname "$0")/../../bin/server_setup
+mix phoenix.server >/dev/null

--- a/elixir_phoenix/bin/teardown
+++ b/elixir_phoenix/bin/teardown
@@ -1,1 +1,0 @@
-../../bin/server_shutdown

--- a/node_express/bin/setup
+++ b/node_express/bin/setup
@@ -1,4 +1,3 @@
 #!/bin/sh
 npm install
-node server.js >/dev/null 2>&1 &
-. $(dirname "$0")/../../bin/server_setup
+node server.js >/dev/null

--- a/node_express/bin/teardown
+++ b/node_express/bin/teardown
@@ -1,1 +1,0 @@
-../../bin/server_shutdown

--- a/ruby_rack/bin/setup
+++ b/ruby_rack/bin/setup
@@ -1,5 +1,4 @@
 #!/bin/sh
 gem list -i bundler >/dev/null || gem install bundler
-bundle check >dev/null || bundle install --path tmp/bundle
-ruby server.rb >/dev/null &
-. $(dirname "$0")/../../bin/server_setup
+bundle check >/dev/null || bundle install --path tmp/bundle
+ruby server.rb >/dev/null

--- a/ruby_rack/bin/teardown
+++ b/ruby_rack/bin/teardown
@@ -1,1 +1,0 @@
-../../bin/server_shutdown

--- a/ruby_sinatra/bin/setup
+++ b/ruby_sinatra/bin/setup
@@ -1,4 +1,3 @@
 #!/bin/sh
-gem list -i sinatra >/dev/null || gem install sinatra --no-ri 
-ruby server.rb >/dev/null 2>&1 &
-. $(dirname "$0")/../../bin/server_setup
+gem list -i sinatra >/dev/null || gem install sinatra --no-ri
+ruby server.rb >/dev/null

--- a/ruby_sinatra/bin/teardown
+++ b/ruby_sinatra/bin/teardown
@@ -1,1 +1,0 @@
-../../bin/server_shutdown


### PR DESCRIPTION
`bin/setup` is now just responsible for running the server in-process, after installing any dependencies. Enclosing make harness is responsible for daemonizing and shutting down the server afterwards. @ageoldpun @mradamh FYI.