### PR TITLE
cleaned up package constraints a bit for standalone build

### DIFF
--- a/haskell_scotty/eboshi-api.cabal
+++ b/haskell_scotty/eboshi-api.cabal
@@ -20,7 +20,7 @@ executable eboshi-api
   main-is:             Server.hs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.6 && <4.7,
-                       scotty
+  build-depends:       base >=4.6 && <5,
+                       scotty >=0.10 && <1
   -- hs-source-dirs:      
   default-language:    Haskell2010


### PR DESCRIPTION
The constraints on base were pretty tight, and the constraints on scotty didn't exist. Fixed.