### PR TITLE
OO-ify node hapi

### DIFF
--- a/node_hapi/app/index.js
+++ b/node_hapi/app/index.js
@@ -2,7 +2,6 @@ import 'babel/polyfill';
 import * as Hapi from 'hapi';
 import * as _ from 'lodash';
 
-import { knex } from './cfg/knex';
 import Client from './models/client';
 
 const server = new Hapi.Server();

--- a/node_hapi/app/index.js
+++ b/node_hapi/app/index.js
@@ -23,7 +23,7 @@ server.route({
     path: '/api/clients',
     handler: async (request, reply) => {
         const clients = await Client.all();
-        reply({ data: _.map(clients, Client.serialize) });
+        reply({ data: _.map(clients, (c) => c.serialize()) });
     }
 });
 
@@ -32,7 +32,7 @@ server.route({
     path: '/api/clients',
     handler: async (request, reply) => {
         const client = await Client.create(request.payload.data.attributes);
-        reply({ data: Client.serialize(client) }).code(201);
+        reply({ data: client.serialize() }).code(201);
     }
 });
 

--- a/node_hapi/app/index.js
+++ b/node_hapi/app/index.js
@@ -3,7 +3,7 @@ import * as Hapi from 'hapi';
 import * as _ from 'lodash';
 
 import { knex } from './cfg/knex';
-import * as Client from './models/client';
+import Client from './models/client';
 
 const server = new Hapi.Server();
 

--- a/node_hapi/app/index.js
+++ b/node_hapi/app/index.js
@@ -31,10 +31,8 @@ server.route({
     method: 'POST',
     path: '/api/clients',
     handler: async (request, reply) => {
-        const client = Client.deserialize(request.payload.data.attributes);
-        const clientId = await knex('clients').insert(client);
-        reply({ data: Client.serialize(_.assign({}, client, { id: clientId })) })
-            .code(201);
+        const client = await Client.create(request.payload.data.attributes);
+        reply({ data: Client.serialize(client) }).code(201);
     }
 });
 

--- a/node_hapi/app/index.js
+++ b/node_hapi/app/index.js
@@ -40,8 +40,8 @@ server.route({
     method: 'DELETE',
     path: '/api/clients/{id}',
     handler: async (request, reply) => {
-        const rowsDeleted = await knex('clients').where('id', request.params.id).del();
-        return rowsDeleted ? reply().code(204) : reply().code(404);
+        const rowsDeleted = await Client.destroy(request.params.id);
+        rowsDeleted ? reply().code(204) : reply().code(404);
     }
 });
 

--- a/node_hapi/app/index.js
+++ b/node_hapi/app/index.js
@@ -22,7 +22,7 @@ server.route({
     method: 'GET',
     path: '/api/clients',
     handler: async (request, reply) => {
-        const clients = await knex.select().table('clients');
+        const clients = await Client.all();
         reply({ data: _.map(clients, Client.serialize) });
     }
 });

--- a/node_hapi/app/models/client.js
+++ b/node_hapi/app/models/client.js
@@ -1,5 +1,10 @@
 import * as _ from 'lodash';
 import moment from 'moment';
+import { knex } from '../cfg/knex';
+
+export async function all() {
+    return await knex.select().table('clients');
+}
 
 // Serialize a client for response
 export function serialize(client) {

--- a/node_hapi/app/models/client.js
+++ b/node_hapi/app/models/client.js
@@ -2,6 +2,10 @@ import * as _ from 'lodash';
 import moment from 'moment';
 import { knex } from '../cfg/knex';
 
+function rfc8601(time) {
+    return moment(time).utc().format('YYYY-MM-DDTHH:mm:ss[Z]');
+}
+
 export default class Client {
     static async all() {
         const results = await knex.select().table('clients');
@@ -29,8 +33,8 @@ export default class Client {
         const attributes = _.chain(this)
             .omit('id')
             .assign({
-                created_at: moment(this.created_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]'),
-                updated_at: moment(this.updated_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
+                created_at: rfc8601(this.created_at),
+                updated_at: rfc8601(this.updated_at)
             })
             .value();
 

--- a/node_hapi/app/models/client.js
+++ b/node_hapi/app/models/client.js
@@ -12,6 +12,10 @@ export async function create(attributes) {
     return _.assign({}, client, { id: clientId });
 }
 
+export async function destroy(id) {
+    return await knex('clients').where('id', id).del();
+}
+
 // Serialize a client for response
 export function serialize(client) {
     const attributes = _.chain(client)

--- a/node_hapi/app/models/client.js
+++ b/node_hapi/app/models/client.js
@@ -25,19 +25,18 @@ export default class Client {
         _.assign(this, attributes);
     }
 
-    // Serialize a client for response
-    static serialize(client) {
-        const attributes = _.chain(client)
+    serialize() {
+        const attributes = _.chain(this)
             .omit('id')
             .assign({
-                created_at: moment(client.created_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]'),
-                updated_at: moment(client.updated_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
+                created_at: moment(this.created_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]'),
+                updated_at: moment(this.updated_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
             })
             .value();
 
         return {
             type: 'clients',
-            id: client.id.toString(),
+            id: this.id.toString(),
             attributes: attributes
         };
     }

--- a/node_hapi/app/models/client.js
+++ b/node_hapi/app/models/client.js
@@ -2,37 +2,38 @@ import * as _ from 'lodash';
 import moment from 'moment';
 import { knex } from '../cfg/knex';
 
-export async function all() {
-    return await knex.select().table('clients');
+export default class Client {
+    static async all() {
+        return await knex.select().table('clients');
+    }
+
+    static async create(attributes) {
+        const client = _.assign({}, attributes, {
+            created_at: new Date(attributes.created_at),
+            updated_at: new Date(attributes.updated_at)
+        });
+        client.id = await knex('clients').insert(client);
+        return client;
+    }
+
+    static async destroy(id) {
+        return await knex('clients').where('id', id).del();
+    }
+
+    // Serialize a client for response
+    static serialize(client) {
+        const attributes = _.chain(client)
+            .omit('id')
+            .assign({
+                created_at: moment(client.created_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]'),
+                updated_at: moment(client.updated_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
+            })
+            .value();
+
+        return {
+            type: 'clients',
+            id: client.id.toString(),
+            attributes: attributes
+        };
+    }
 }
-
-export async function create(attributes) {
-    const client = _.assign({}, attributes, {
-        created_at: new Date(attributes.created_at),
-        updated_at: new Date(attributes.updated_at)
-    });
-    client.id = await knex('clients').insert(client);
-    return client;
-}
-
-export async function destroy(id) {
-    return await knex('clients').where('id', id).del();
-}
-
-// Serialize a client for response
-export function serialize(client) {
-    const attributes = _.chain(client)
-        .omit('id')
-        .assign({
-            created_at: moment(client.created_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]'),
-            updated_at: moment(client.updated_at).utc().format('YYYY-MM-DDTHH:mm:ss[Z]')
-        })
-        .value();
-
-    return {
-        type: 'clients',
-        id: client.id.toString(),
-        attributes: attributes
-    };
-}
-

--- a/node_hapi/app/models/client.js
+++ b/node_hapi/app/models/client.js
@@ -4,20 +4,25 @@ import { knex } from '../cfg/knex';
 
 export default class Client {
     static async all() {
-        return await knex.select().table('clients');
+        const results = await knex.select().table('clients');
+        return _.map(results, (attributes) => { return new Client(attributes); });
     }
 
     static async create(attributes) {
-        const client = _.assign({}, attributes, {
+        const id = await knex('clients').insert(attributes);
+        return _.assign(new Client(attributes), {
+            id: id,
             created_at: new Date(attributes.created_at),
             updated_at: new Date(attributes.updated_at)
         });
-        client.id = await knex('clients').insert(client);
-        return client;
     }
 
     static async destroy(id) {
         return await knex('clients').where('id', id).del();
+    }
+
+    constructor(attributes) {
+        _.assign(this, attributes);
     }
 
     // Serialize a client for response

--- a/node_hapi/app/models/client.js
+++ b/node_hapi/app/models/client.js
@@ -6,6 +6,12 @@ export async function all() {
     return await knex.select().table('clients');
 }
 
+export async function create(attributes) {
+    const client = deserialize(attributes);
+    const clientId = await knex('clients').insert(client);
+    return _.assign({}, client, { id: clientId });
+}
+
 // Serialize a client for response
 export function serialize(client) {
     const attributes = _.chain(client)

--- a/node_hapi/app/models/client.js
+++ b/node_hapi/app/models/client.js
@@ -7,9 +7,12 @@ export async function all() {
 }
 
 export async function create(attributes) {
-    const client = deserialize(attributes);
-    const clientId = await knex('clients').insert(client);
-    return _.assign({}, client, { id: clientId });
+    const client = _.assign({}, attributes, {
+        created_at: new Date(attributes.created_at),
+        updated_at: new Date(attributes.updated_at)
+    });
+    client.id = await knex('clients').insert(client);
+    return client;
 }
 
 export async function destroy(id) {
@@ -33,10 +36,3 @@ export function serialize(client) {
     };
 }
 
-// deserialize a client from json-api
-export function deserialize(client) {
-    return _.assign(client, {
-        created_at: new Date(client.created_at),
-        updated_at: new Date(client.updated_at)
-    });
-}


### PR DESCRIPTION
@mradamh Was poking around your `node_hapi` impl, and decided to try out the new ES6 class system. I ended up with this refactoring, which I'll leave up to you to merge or close. This is your impl, not mine!

Benefits:
* Lower-level details have been extracted out of the main "controller", which now only knows about http, some top-level serialization, and Client.
* Client is cohesive, reusable, and can now be unit tested.
* Only Client is coupled to knex now, so it'd be simpler to swap out a different db access layer in the future.

Demerits:
* More indirection.

What do you think?