### PR TITLE
Use same root module for Repo and Web

### DIFF
--- a/elixir_phoenix/config/config.exs
+++ b/elixir_phoenix/config/config.exs
@@ -5,7 +5,7 @@
 # is restricted to this project.
 use Mix.Config
 
-config :eboshi_api_shootout_elixir_phoenix, EboshiApiShootoutElixirPhoenix.Repo,
+config :elixir_phoenix, ElixirPhoenix.Repo,
   adapter: Ecto.Adapters.MySQL,
   database: "eboshi_test",
   username: "root",

--- a/elixir_phoenix/lib/eboshi_api_shootout_elixir_phoenix/repo.ex
+++ b/elixir_phoenix/lib/eboshi_api_shootout_elixir_phoenix/repo.ex
@@ -1,3 +1,3 @@
-defmodule EboshiApiShootoutElixirPhoenix.Repo do
-  use Ecto.Repo, otp_app: :eboshi_api_shootout_elixir_phoenix
+defmodule ElixirPhoenix.Repo do
+  use Ecto.Repo, otp_app: :elixir_phoenix
 end

--- a/elixir_phoenix/lib/elixir_phoenix.ex
+++ b/elixir_phoenix/lib/elixir_phoenix.ex
@@ -9,7 +9,7 @@ defmodule ElixirPhoenix do
     children = [
       # Start the endpoint when the application starts
       supervisor(ElixirPhoenix.Endpoint, []),
-      worker(EboshiApiShootoutElixirPhoenix.Repo, []),
+      worker(ElixirPhoenix.Repo, []),
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/elixir_phoenix/mix.exs
+++ b/elixir_phoenix/mix.exs
@@ -2,7 +2,7 @@ defmodule ElixirPhoenix.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :eboshi_api_shootout_elixir_phoenix,
+    [app: :elixir_phoenix,
      version: "0.0.1",
      elixir: "~> 1.0",
      elixirc_paths: elixirc_paths(Mix.env),

--- a/elixir_phoenix/priv/repo/migrations/20150930050801_create_client.exs
+++ b/elixir_phoenix/priv/repo/migrations/20150930050801_create_client.exs
@@ -1,4 +1,4 @@
-defmodule EboshiApiShootoutElixirPhoenix.Repo.Migrations.CreateClient do
+defmodule ElixirPhoenix.Repo.Migrations.CreateClient do
   use Ecto.Migration
 
   def change do

--- a/elixir_phoenix/web/controllers/client_controller.ex
+++ b/elixir_phoenix/web/controllers/client_controller.ex
@@ -1,8 +1,8 @@
 defmodule ElixirPhoenix.ClientController do
   use ElixirPhoenix.Web, :controller
 
-  alias EboshiApiShootoutElixirPhoenix.Client
-  alias EboshiApiShootoutElixirPhoenix.Repo
+  alias ElixirPhoenix.Client
+  alias ElixirPhoenix.Repo
 
   plug :scrub_params, "data" when action in [:create, :update]
 
@@ -23,7 +23,7 @@ defmodule ElixirPhoenix.ClientController do
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> render(EboshiApiShootoutElixirPhoenix.ChangesetView, "error.json", changeset: changeset)
+        |> render(ElixirPhoenix.ChangesetView, "error.json", changeset: changeset)
     end
   end
 
@@ -42,7 +42,7 @@ defmodule ElixirPhoenix.ClientController do
       {:error, changeset} ->
         conn
         |> put_status(:unprocessable_entity)
-        |> render(EboshiApiShootoutElixirPhoenix.ChangesetView, "error.json", changeset: changeset)
+        |> render(ElixirPhoenix.ChangesetView, "error.json", changeset: changeset)
     end
   end
 

--- a/elixir_phoenix/web/models/client.ex
+++ b/elixir_phoenix/web/models/client.ex
@@ -1,4 +1,4 @@
-defmodule EboshiApiShootoutElixirPhoenix.Client do
+defmodule ElixirPhoenix.Client do
   use Ecto.Model
 
   schema "clients" do


### PR DESCRIPTION
i was apparently fighting some defaults and conventions by having a different root module for the ecto Repo vs. the rest of the app.