### PR TITLE
fixed test framework to honor database password

### DIFF
--- a/test/support/db.rb
+++ b/test/support/db.rb
@@ -17,10 +17,12 @@ class DB
   private
 
   def query statement
+    process_password
     system "mysql -u'#{username}' #{database} -e'#{statement}'"
   end
 
   def create_database
+    process_password
     statement = "CREATE DATABASE IF NOT EXISTS `#{database}`;"
     system "mysql -u'#{username}' -e'#{statement}'"
   end
@@ -29,8 +31,10 @@ class DB
     ENV["EBOSHI_API_SHOOTOUT_MYSQL_USERNAME"] || "root"
   end
 
-  def password
-    ENV["EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD"] || ""
+  def process_password
+    if ENV["EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD"] then
+      ENV["MYSQL_PWD"] = ENV["EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD"]
+    end
   end
 
   def database

--- a/test/support/db.rb
+++ b/test/support/db.rb
@@ -17,12 +17,12 @@ class DB
   private
 
   def query statement
-    process_password
+    set_password
     system "mysql -u'#{username}' #{database} -e'#{statement}'"
   end
 
   def create_database
-    process_password
+    set_password
     statement = "CREATE DATABASE IF NOT EXISTS `#{database}`;"
     system "mysql -u'#{username}' -e'#{statement}'"
   end
@@ -31,10 +31,8 @@ class DB
     ENV["EBOSHI_API_SHOOTOUT_MYSQL_USERNAME"] || "root"
   end
 
-  def process_password
-    if ENV["EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD"] then
-      ENV["MYSQL_PWD"] = ENV["EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD"]
-    end
+  def set_password
+    ENV["MYSQL_PWD"] = ENV["EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD"]
   end
 
   def database


### PR DESCRIPTION
The database password from the environment variable EBOSHI_API_SHOOTOUT_MYSQL_PASSWORD wasn't being used by the test script. I needed it, so I set MYSQL_PWD to it if it is set. Now the code runs on my box.